### PR TITLE
Add regex option for sorting by file name (v0.6.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cabinet"
-version = "0.5.2"
+version = "0.6.0"
 license = "MPL-2.0"
 description = "A convenient file sorting utility"
 readme = "README.md"

--- a/src/commands/multisort.rs
+++ b/src/commands/multisort.rs
@@ -161,9 +161,10 @@ pub fn exec(args: &ArgMatches) {
 
     let mut new_files: Vec<Rc<DirEntry>> = vec![];
 
+    let mut has_include = false;
+    let mut has_exclude = false;
+
     if use_regex {
-        let mut has_include = false;
-        let mut has_exclude = false;
         let mut include: Regex = Regex::new("").unwrap();
         let mut exclude: Regex = Regex::new("").unwrap();
 
@@ -216,8 +217,6 @@ pub fn exec(args: &ArgMatches) {
             files = vec![];
         }
     } else {
-        let mut has_include = false;
-        let mut has_exclude = false;
         let mut include = String::new();
         let mut exclude = String::new();
 
@@ -233,7 +232,7 @@ pub fn exec(args: &ArgMatches) {
         for item in &files {
             let md = item.metadata().unwrap();
 
-            let filename = &item.file_name(); // gets the name (no file extension)
+            let filename = &item.file_name();
             let f = OsStr::to_str(&filename).unwrap();
 
             if md.is_file() {
@@ -241,9 +240,7 @@ pub fn exec(args: &ArgMatches) {
                     new_files.push(Rc::clone(&item));
                 } else if (has_include && !has_exclude) && f.contains(&include) {
                     new_files.push(Rc::clone(&item));
-                }
-                // Only add file if it DOESN'T include the pattern (since it is exclude pattern)
-                else if (has_exclude && !has_include) && !f.contains(&exclude) {
+                } else if (has_exclude && !has_include) && !f.contains(&exclude) {
                     new_files.push(Rc::clone(&item));
                 }
             }
@@ -388,6 +385,8 @@ pub fn exec(args: &ArgMatches) {
     } else if new_files.is_empty() && (has_min || has_max) {
         files = vec![];
     }
+
+    // Sort by type
 
     if file_type != None {
         let mut new_files: Vec<Rc<DirEntry>> = vec![];

--- a/src/commands/multisort.rs
+++ b/src/commands/multisort.rs
@@ -58,6 +58,11 @@ pub fn cli() -> Command {
                 .value_name("file-type")
                 .help("Sort files according to the specific file type")
                 .action(clap::ArgAction::Set),
+            Arg::new("regex")
+                .short('R')
+                .long("regex")
+                .value_name("match")
+                .help("Use regular expressions (regex) for pattern matching of file names"),
             Arg::new("template")
                 .short('t')
                 .long("template")
@@ -103,6 +108,7 @@ pub fn exec(args: &ArgMatches) {
 
     let mut include_pattern: Option<String> = None;
     let mut exclude_pattern: Option<String> = None;
+    let use_regex = args.get_flag("regex");
     if let Some(incl) = args.get_one::<String>("includes") {
         include_pattern = Some(incl.to_string());
     }
@@ -153,46 +159,102 @@ pub fn exec(args: &ArgMatches) {
 
     // Sort by name
 
-    let mut has_include = false;
-    let mut has_exclude = false;
-    let mut include = String::new();
-    let mut exclude = String::new();
-
-    if include_pattern != None {
-        has_include = true;
-        include = include_pattern.unwrap();
-    }
-    if exclude_pattern != None {
-        has_exclude = true;
-        exclude = exclude_pattern.unwrap();
-    }
-
     let mut new_files: Vec<Rc<DirEntry>> = vec![];
 
-    for item in &files {
-        let md = item.metadata().unwrap();
+    if use_regex {
+        let mut has_include = false;
+        let mut has_exclude = false;
+        let mut include: Regex = Regex::new("").unwrap();
+        let mut exclude: Regex = Regex::new("").unwrap();
 
-        let filename = &item.file_name(); // gets the name (no file extension)
-        let f = OsStr::to_str(&filename).unwrap();
+        if include_pattern != None {
+            has_include = true;
+            include = Regex::new(include_pattern.unwrap().as_str()).unwrap();
+        }
+        if exclude_pattern != None {
+            has_exclude = true;
+            exclude = Regex::new(exclude_pattern.unwrap().as_str()).unwrap();
+        }
 
-        if md.is_file() {
-            if (has_include && has_exclude) && (f.contains(&include) && !f.contains(&exclude)) {
-                new_files.push(Rc::clone(&item));
-            } else if (has_include && !has_exclude) && f.contains(&include) {
-                new_files.push(Rc::clone(&item));
-            }
-            // Only add file if it DOESN'T include the pattern (since it is exclude pattern)
-            else if (has_exclude && !has_include) && !f.contains(&exclude) {
-                new_files.push(Rc::clone(&item));
+        for item in &files {
+            let md = item.metadata().unwrap();
+
+            let filename = &item.file_name();
+            let f = OsStr::to_str(&filename).unwrap();
+
+            if md.is_file() {
+                if has_include && has_exclude {
+                    match include.captures(f) {
+                        Some(_) => {}
+                        None => continue,
+                    };
+                    match exclude.captures(f) {
+                        Some(_) => {}
+                        None => continue,
+                    };
+                    new_files.push(Rc::clone(&item));
+                } else if has_include && !has_exclude {
+                    match include.captures(f) {
+                        Some(_) => {}
+                        None => continue,
+                    };
+                    new_files.push(Rc::clone(&item));
+                } else if has_exclude && !has_include {
+                    match exclude.captures(f) {
+                        Some(_) => {}
+                        None => continue,
+                    };
+                    new_files.push(Rc::clone(&item));
+                }
             }
         }
-    }
 
-    if !&new_files.is_empty() {
-        files = new_files;
-        sort_files = true;
-    } else if new_files.is_empty() && (has_include || has_exclude) {
-        files = vec![];
+        if !&new_files.is_empty() {
+            files = new_files;
+            sort_files = true;
+        } else if new_files.is_empty() && (has_include || has_exclude) {
+            files = vec![];
+        }
+    } else {
+        let mut has_include = false;
+        let mut has_exclude = false;
+        let mut include = String::new();
+        let mut exclude = String::new();
+
+        if include_pattern != None {
+            has_include = true;
+            include = include_pattern.unwrap();
+        }
+        if exclude_pattern != None {
+            has_exclude = true;
+            exclude = exclude_pattern.unwrap();
+        }
+
+        for item in &files {
+            let md = item.metadata().unwrap();
+
+            let filename = &item.file_name(); // gets the name (no file extension)
+            let f = OsStr::to_str(&filename).unwrap();
+
+            if md.is_file() {
+                if (has_include && has_exclude) && (f.contains(&include) && !f.contains(&exclude)) {
+                    new_files.push(Rc::clone(&item));
+                } else if (has_include && !has_exclude) && f.contains(&include) {
+                    new_files.push(Rc::clone(&item));
+                }
+                // Only add file if it DOESN'T include the pattern (since it is exclude pattern)
+                else if (has_exclude && !has_include) && !f.contains(&exclude) {
+                    new_files.push(Rc::clone(&item));
+                }
+            }
+        }
+
+        if !&new_files.is_empty() {
+            files = new_files;
+            sort_files = true;
+        } else if new_files.is_empty() && (has_include || has_exclude) {
+            files = vec![];
+        }
     }
 
     // Sort by date

--- a/src/commands/name.rs
+++ b/src/commands/name.rs
@@ -3,6 +3,7 @@ use std::fs::{self, DirEntry};
 use std::path::PathBuf;
 
 use clap::{Arg, ArgMatches, Command};
+use regex::Regex;
 
 use crate::util;
 use crate::util::path::get_path;
@@ -23,6 +24,12 @@ pub fn cli() -> Command {
                 .value_name("match")
                 .help("File name excludes...")
                 .action(clap::ArgAction::Set),
+            Arg::new("regex")
+                .short('R')
+                .long("regex")
+                .value_name("match")
+                .help("Use regular expressions (regex) for pattern matching")
+                .action(clap::ArgAction::SetTrue),
             Arg::new("template")
                 .short('t')
                 .long("template")
@@ -53,6 +60,7 @@ pub fn exec(args: &ArgMatches) {
 
     let mut include_pattern: Option<String> = None;
     let mut exclude_pattern: Option<String> = None;
+    let use_regex = args.get_flag("regex");
 
     if let Some(incl) = args.get_one::<String>("includes") {
         include_pattern = Some(incl.to_string());
@@ -67,20 +75,6 @@ pub fn exec(args: &ArgMatches) {
         return;
     }
 
-    let mut has_include = false;
-    let mut has_exclude = false;
-    let mut include = String::new();
-    let mut exclude = String::new();
-
-    if include_pattern != None {
-        has_include = true;
-        include = include_pattern.unwrap();
-    }
-    if exclude_pattern != None {
-        has_exclude = true;
-        exclude = exclude_pattern.unwrap();
-    }
-
     let dir = fs::read_dir(path.as_ref().unwrap()).unwrap();
     let paths_parent = path.as_ref().unwrap().display().to_string();
     let parent = path.unwrap();
@@ -88,22 +82,84 @@ pub fn exec(args: &ArgMatches) {
 
     let mut files: Vec<DirEntry> = vec![];
 
-    for item in dir {
-        let item = item.unwrap();
-        let md = item.metadata().unwrap();
+    if use_regex {
+        let mut has_include = false;
+        let mut has_exclude = false;
+        let mut include: Regex = Regex::new("").unwrap();
+        let mut exclude: Regex = Regex::new("").unwrap();
 
-        let filename = &item.file_name(); // gets the name (no file extension)
-        let f = OsStr::to_str(&filename).unwrap();
+        if include_pattern != None {
+            has_include = true;
+            include = Regex::new(include_pattern.unwrap().as_str()).unwrap();
+        }
+        if exclude_pattern != None {
+            has_exclude = true;
+            exclude = Regex::new(exclude_pattern.unwrap().as_str()).unwrap();
+        }
 
-        if md.is_file() {
-            if (has_include && has_exclude) && (f.contains(&include) && !f.contains(&exclude)) {
-                files.push(item);
-            } else if (has_include && !has_exclude) && f.contains(&include) {
-                files.push(item);
+        for item in dir {
+            let item = item.unwrap();
+            let md = item.metadata().unwrap();
+
+            let filename = &item.file_name();
+            let f = OsStr::to_str(&filename).unwrap();
+
+            if md.is_file() {
+                if has_include && has_exclude {
+                    match include.captures(f) {
+                        Some(_) => {}
+                        None => continue,
+                    };
+                    match exclude.captures(f) {
+                        Some(_) => {}
+                        None => continue,
+                    };
+                    files.push(item);
+                } else if has_include && !has_exclude {
+                    match include.captures(f) {
+                        Some(_) => {}
+                        None => continue,
+                    };
+                    files.push(item);
+                } else if has_exclude && !has_include {
+                    match exclude.captures(f) {
+                        Some(_) => {}
+                        None => continue,
+                    };
+                    files.push(item);
+                }
             }
-            // Only add file if it DOESN'T include the pattern (since it is exclude pattern)
-            else if (has_exclude && !has_include) && !f.contains(&exclude) {
-                files.push(item);
+        }
+    } else {
+        let mut has_include = false;
+        let mut has_exclude = false;
+        let mut include = String::new();
+        let mut exclude = String::new();
+
+        if include_pattern != None {
+            has_include = true;
+            include = include_pattern.unwrap();
+        }
+        if exclude_pattern != None {
+            has_exclude = true;
+            exclude = exclude_pattern.unwrap();
+        }
+
+        for item in dir {
+            let item = item.unwrap();
+            let md = item.metadata().unwrap();
+
+            let filename = &item.file_name(); // gets the name (no file extension)
+            let f = OsStr::to_str(&filename).unwrap();
+
+            if md.is_file() {
+                if (has_include && has_exclude) && (f.contains(&include) && !f.contains(&exclude)) {
+                    files.push(item);
+                } else if (has_include && !has_exclude) && f.contains(&include) {
+                    files.push(item);
+                } else if (has_exclude && !has_include) && !f.contains(&exclude) {
+                    files.push(item);
+                }
             }
         }
     }

--- a/src/commands/name.rs
+++ b/src/commands/name.rs
@@ -82,9 +82,10 @@ pub fn exec(args: &ArgMatches) {
 
     let mut files: Vec<DirEntry> = vec![];
 
+    let mut has_include = false;
+    let mut has_exclude = false;
+
     if use_regex {
-        let mut has_include = false;
-        let mut has_exclude = false;
         let mut include: Regex = Regex::new("").unwrap();
         let mut exclude: Regex = Regex::new("").unwrap();
 
@@ -131,8 +132,6 @@ pub fn exec(args: &ArgMatches) {
             }
         }
     } else {
-        let mut has_include = false;
-        let mut has_exclude = false;
         let mut include = String::new();
         let mut exclude = String::new();
 
@@ -149,7 +148,7 @@ pub fn exec(args: &ArgMatches) {
             let item = item.unwrap();
             let md = item.metadata().unwrap();
 
-            let filename = &item.file_name(); // gets the name (no file extension)
+            let filename = &item.file_name();
             let f = OsStr::to_str(&filename).unwrap();
 
             if md.is_file() {

--- a/src/util/utils.rs
+++ b/src/util/utils.rs
@@ -34,14 +34,9 @@ pub fn create_folder(path: PathBuf, folder: String, auto_yes: bool) -> Result<Pa
         let _ = stdout().flush();
         let mut ans = String::new();
         stdin().read_line(&mut ans).expect("Malformed input");
-        if let Some('\n') = ans.chars().next_back() {
-            ans.pop();
-        }
-        if let Some('\r') = ans.chars().next_back() {
-            ans.pop();
-        }
 
-        if ans == "y" {
+        // could also use .trim_end_matches('\n').trim_end_matches('\r') // ORDER IS IMPORTANT
+        if ans.trim_end() == "y" {
             println!("\nContinuing anyway...");
             return Ok(path);
         } else {
@@ -91,7 +86,6 @@ pub fn sort_files(path: &PathBuf, files: &Vec<DirEntry>) {
     let duration = start.elapsed();
     stdout.flush().unwrap();
 
-    // NOTE: \t doesn't seem to actually work in clearing everything - you get "Processed 100%9%"
     print!("\rProcessed 100%   \n");
     println!("Time taken: {:?}", duration);
     println!(
@@ -121,7 +115,6 @@ pub fn sort_files_rc(path: &PathBuf, files: &Vec<Rc<DirEntry>>) {
     let duration = start.elapsed();
     stdout.flush().unwrap();
 
-    // NOTE: \t doesn't seem to actually work in clearing everything - you get "Processed 100%9%"
     print!("\rProcessed 100%   \n");
     println!("Time taken: {:?}", duration);
     println!(


### PR DESCRIPTION
Added the option to sort files using regex by using the `-R` or `--regex` flag. This works for both the `name` and `multisort` commands.